### PR TITLE
Use the GitHub Cache for Docker builds

### DIFF
--- a/.github/workflows/app-build-and-push.yaml
+++ b/.github/workflows/app-build-and-push.yaml
@@ -113,7 +113,8 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: .
-          no-cache: true # Waiting for https://github.com/docker/buildx/pull/535
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           file: ./Dockerfile
           platforms: linux/amd64, linux/arm64
           build-args: |
@@ -218,7 +219,8 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: .
-          no-cache: true # Waiting for https://github.com/docker/buildx/pull/535
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           file: ./Dockerfile
           platforms: linux/amd64, linux/arm64
           build-args: |
@@ -297,7 +299,8 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: .
-          no-cache: true # Waiting for https://github.com/docker/buildx/pull/535
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           file: ./Dockerfile
           platforms: linux/amd64, linux/arm64
           build-args: |


### PR DESCRIPTION
Now that GitHub workers were 100% updated with the new images, let's add caching!